### PR TITLE
making ouija use config.py for user with docker

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -1,0 +1,3 @@
+DB_USER = 'ouija_user'
+DB_HOST = 'database'
+DB_NAME = 'ouija'

--- a/config/config.py
+++ b/config/config.py
@@ -1,3 +1,5 @@
 DB_USER = 'ouija_user'
 DB_HOST = 'database'
 DB_NAME = 'ouija'
+
+DEBUG = False

--- a/src/server.py
+++ b/src/server.py
@@ -12,6 +12,7 @@ from flask import Flask, request, json, Response, abort
 
 static_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "static"))
 app = Flask(__name__, static_url_path="", static_folder=static_path)
+app.config.from_pyfile('../config/config.py') 
 
 class CSetSummary(object):
     def __init__(self, cset_id):
@@ -23,10 +24,10 @@ class CSetSummary(object):
 
 
 def create_db_connnection():
-    return MySQLdb.connect(host="localhost",
-                           user="root",
-                           passwd="root",
-                           db="ouija")
+    return MySQLdb.connect(host=app.config['DB_HOST'],
+                           user=app.config['DB_USER'],
+                           passwd="",
+                           db=app.config['DB_NAME'])
 
 
 def serialize_to_json(object):
@@ -419,4 +420,4 @@ def template(filename):
     abort(404)
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8157, debug=False)
+    app.run(host="0.0.0.0", port=8157, debug=True)

--- a/src/server.py
+++ b/src/server.py
@@ -420,4 +420,4 @@ def template(filename):
     abort(404)
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8157, debug=True)
+    app.run(host="0.0.0.0", port=8157, debug=app.config['DEBUG'])


### PR DESCRIPTION
This pull request is to make ouija work with Docker, which I have built over in https://github.com/jamonation/ouija_docker (based on https://bugzilla.mozilla.org/show_bug.cgi?id=1010465)

This repository is a git submodule inside the docker container so that it can remain as a standalone python virtualenv, in addition to working inside Docker.

Testing and feedback are much appreciated!