### PR TITLE
send note only when new tests on the list

### DIFF
--- a/tools/failures.py
+++ b/tools/failures.py
@@ -189,10 +189,13 @@ def print_diff(start_date, end_date):
     else:
         deletion = list(set(start_tuple) - set(end_tuple))
         deletion.sort()
-        if not deletion:
+        if deletion:
+            print "%s: These jobs have changed from the previous day: %s" % \
+                  (end_date.strftime("%Y-%m-%d"), deletion)
+        else:
             deletion = ''
-        print "%s: These jobs have changed from the previous day: %s" % \
-              (end_date.strftime("%Y-%m-%d"), deletion)
+            print "%s: NO job been changed from the previous day" % \
+                  (end_date.strftime("%Y-%m-%d"))
         return deletion
 
 


### PR DESCRIPTION
Here is what I found,

If we have a previous job list(start_tuple) like [job1, job2, job3] and the job list we have now(end_tuple) is [job1, job2, job3, job4].

If we use start_tuple - end_tuple, the list we got will be [] and it's the reason why we only get notification when old job been removing rather than new one been added.

So, we could just inverse them which use end_tuple to minus the start_tuple to make it works when new one been added.