### PR TITLE
Add windows7-32-vm to platform_map

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -472,6 +472,7 @@ def buildbot_name(platform, buildtype, jobname, branch):
     platform_map['linux64asan'] = "Ubuntu ASAN VM 12.04 x64"
     platform_map['windowsxp'] = "Windows XP 32-bit"
     platform_map['windows7-32'] = "Windows 7 32-bit"
+    platform_map['windows7-32-vm'] = "Windows 7 32-bit VM"
     platform_map['windows8-64'] = "Windows 8 64-bit"
 
     buildtype_map = {}


### PR DESCRIPTION
This change is already applied on the server; it was necessary to unbreak buildbot reconfigs, which were failing because SETA was returning an HTTP 500 error:

[Tue Jul 12 20:24:55.504320 2016] [:error] [pid 1559:tid 140197754570496] ERROR:server:Exception on /data/setadetails/ [GET]
[Tue Jul 12 20:24:55.504395 2016] [:error] [pid 1559:tid 140197754570496] Traceback (most recent call last):
[Tue Jul 12 20:24:55.504405 2016] [:error] [pid 1559:tid 140197754570496]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
[Tue Jul 12 20:24:55.504414 2016] [:error] [pid 1559:tid 140197754570496]     response = self.full_dispatch_request()
[Tue Jul 12 20:24:55.504422 2016] [:error] [pid 1559:tid 140197754570496]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
[Tue Jul 12 20:24:55.504430 2016] [:error] [pid 1559:tid 140197754570496]     rv = self.handle_user_exception(e)
[Tue Jul 12 20:24:55.504438 2016] [:error] [pid 1559:tid 140197754570496]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
[Tue Jul 12 20:24:55.504447 2016] [:error] [pid 1559:tid 140197754570496]     reraise(exc_type, exc_value, tb)
[Tue Jul 12 20:24:55.504455 2016] [:error] [pid 1559:tid 140197754570496]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
[Tue Jul 12 20:24:55.504463 2016] [:error] [pid 1559:tid 140197754570496]     rv = self.dispatch_request()
[Tue Jul 12 20:24:55.504471 2016] [:error] [pid 1559:tid 140197754570496]   File "/usr/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
[Tue Jul 12 20:24:55.504479 2016] [:error] [pid 1559:tid 140197754570496]     return self.view_functions[rule.endpoint](**req.view_args)
[Tue Jul 12 20:24:55.504487 2016] [:error] [pid 1559:tid 140197754570496]   File "/home/ubuntu/ouija/src/server.py", line 51, in wrapper
[Tue Jul 12 20:24:55.504495 2016] [:error] [pid 1559:tid 140197754570496]     result = json.dumps(func(*args, **kwargs) or {"error": "No data found for your request"},
[Tue Jul 12 20:24:55.504504 2016] [:error] [pid 1559:tid 140197754570496]   File "/home/ubuntu/ouija/src/server.py", line 454, in run_seta_details_query
[Tue Jul 12 20:24:55.504512 2016] [:error] [pid 1559:tid 140197754570496]     active_jobs.append(buildbot_name(job[0], job[1], job[2], branch))
[Tue Jul 12 20:24:55.504520 2016] [:error] [pid 1559:tid 140197754570496]   File "/home/ubuntu/ouija/src/server.py", line 495, in buildbot_name
[Tue Jul 12 20:24:55.504528 2016] [:error] [pid 1559:tid 140197754570496]     return "%s %s %s %s" % (platform_map[platform], branch, buildtype_map[buildtype], jobname)
[Tue Jul 12 20:24:55.504536 2016] [:error] [pid 1559:tid 140197754570496] KeyError: 'windows7-32-vm'