### PR TITLE
Do not drop jobpriorities as it might not exist

### DIFF
--- a/sql/jobpriorities.sql
+++ b/sql/jobpriorities.sql
@@ -1,7 +1,5 @@
 USE ouija;
 
-drop table jobpriorities;
-
 CREATE TABLE IF NOT EXISTS `jobpriorities` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `platform` varchar(32) NOT NULL,


### PR DESCRIPTION
r? @jmaher

That drop statement was getting on the way when starting from a clean state.