### PR TITLE
Run update_runnablejobs.py on schedule

### DIFF
--- a/schduler/clock.py
+++ b/schduler/clock.py
@@ -2,7 +2,11 @@ from rq import Queue
 from worker import conn
 import logging
 from apscheduler.schedulers.blocking import BlockingScheduler
-from trigger_jobs import trigger_migratedb, trigger_failures
+from trigger_jobs import (
+    trigger_failures,
+    trigger_migratedb,
+    trigger_update_job_priority_table,
+)
 
 
 logger = logging.info(__name__)
@@ -19,6 +23,11 @@ def timed_trigger_updatedb():
 @sched.scheduled_job('cron', day_of_week='mon-sun', hour=13)
 def timed_trigger_updatedb_sec():
     q.enqueue(trigger_migratedb)
+
+
+@sched.scheduled_job('cron', day_of_week='mon-sun', hour=12)
+def timed_trigger_updatedb():
+    q.enqueue(trigger_update_job_priority_table)
 
 
 @sched.scheduled_job('cron', day_of_week='mon-sun', hour=14)

--- a/schduler/trigger_jobs.py
+++ b/schduler/trigger_jobs.py
@@ -9,3 +9,5 @@ def trigger_migratedb():
 def trigger_failures():
     os.system("python tools/failures.py")
 
+def trigger_update_job_priority_table():
+    os.system("python tools/update_runnablejobs.py")


### PR DESCRIPTION
This will ensure that we have an up-to-date job priority table once a
day.

By adding this change, we can stop calling this script if
runnable_jobs.json is not on disk.

@MikeLing @jmaher what do you think?

I believe in this change we should also stop calling update_runnablejobs to prevent race conditions; what do you think?